### PR TITLE
MSA: -use printing policy; -should now be able to report copy/move of…

### DIFF
--- a/lib/Analyses/MoveSemanticsAnalysis.cpp
+++ b/lib/Analyses/MoveSemanticsAnalysis.cpp
@@ -73,10 +73,10 @@ void MoveSemanticsAnalysis::CopyOrMoveAnalyzer::analyzeFeatures() {
                 // CXXConstructExpr, and I don't understand why
                 cxxBindTemporaryExpr(has(cxxConstructExpr().bind("arg"))))),
             // Type of parameter should by-value
-            parmVarDecl(
-                hasType(type(unless(referenceType()))),
-                isExpansionInMainFile()).bind("parm")))
-            .bind("callexpr");
+            // and is not required to be isExpansionInMainFile, perfectly
+            // fine to call function from other TU by value
+            parmVarDecl(hasType(type(unless(referenceType())))).bind("parm")))
+    .bind("callexpr");
     auto Res = Extractor.extract2(*Context, m);
     auto Args = getASTNodes<clang::CXXConstructExpr>(Res, "arg");
     auto Parms = getASTNodes<clang::ParmVarDecl>(Res, "parm");
@@ -88,6 +88,7 @@ void MoveSemanticsAnalysis::CopyOrMoveAnalyzer::analyzeFeatures() {
         auto p = Parms.at(idx);
         auto a = Args.at(idx);
         auto c = Calls.at(idx);
+        // what callee should we get here?
         auto f = c.Node->getDirectCallee();
         FunctionParamInfo FPI;
         CallExprInfo CEI;
@@ -116,8 +117,12 @@ void MoveSemanticsAnalysis::CopyOrMoveAnalyzer::analyzeFeatures() {
         // if(auto r = clang::dyn_cast<clang::CXXTemporaryObjectExpr>(a.Node))
         //     std::cout << r->isElidable() << "\n";
 
-        // what callee should we get here?
-        FPI.FuncId = f->getQualifiedNameAsString();
+        std::string Result;
+        llvm::raw_string_ostream stream(Result);
+        // Can't use getQualifiedNameAsString, will print unwritten scope
+        // Can't use getNameForDiagnostic, will print specialization argument
+        f->printQualifiedName(stream, PP);
+        FPI.FuncId = Result;
         FPI.FuncType = f->getType().getAsString(PP);
         FPI.Id = p.Node->getQualifiedNameAsString();
         FPI.FuncLocation = Context->getFullLoc(f->getInnerLocStart())

--- a/test/unit/library/MoveVsMove.cpp
+++ b/test/unit/library/MoveVsMove.cpp
@@ -19,7 +19,7 @@ int main(int argc, char** argv){
     //
     std::vector<int> v;
     std::list<int> l;
-    std::move(v.begin(), v.end(), std::back_inserter(l));
+    std::move(v.begin(), v.end(), std::back_inserter(l)); // ATTENTION: this call to algorith:std::move will cause three move-constructed parameter to be detected
     //
     return std::move(0);
 

--- a/test/unit/library/MoveVsMove.cpp.json
+++ b/test/unit/library/MoveVsMove.cpp.json
@@ -33,6 +33,49 @@
                 ]
             }
         },
-        "copy or move construction": null
+        "copy or move construction": [
+            {
+                "CallExpr": {
+                    "Location": 22
+                },
+                "Parameter": {
+                    "Func Identifier": "std::move",
+                    "Func Location": 1889,
+                    "Func Type": "class std::back_insert_iterator<class std::list<int, class std::allocator<int> > > (class std::__wrap_iter<int *>, class std::__wrap_iter<int *>, class std::back_insert_iterator<class std::list<int, class std::allocator<int> > >)",
+                    "Identifier": "__first",
+                    "Parm Type": "class std::__wrap_iter<int *>",
+                    "construction kind": "move",
+                    "copy/move ctor is compiler-generated": true
+                }
+            },
+            {
+                "CallExpr": {
+                    "Location": 22
+                },
+                "Parameter": {
+                    "Func Identifier": "std::move",
+                    "Func Location": 1889,
+                    "Func Type": "class std::back_insert_iterator<class std::list<int, class std::allocator<int> > > (class std::__wrap_iter<int *>, class std::__wrap_iter<int *>, class std::back_insert_iterator<class std::list<int, class std::allocator<int> > >)",
+                    "Identifier": "__last",
+                    "Parm Type": "class std::__wrap_iter<int *>",
+                    "construction kind": "move",
+                    "copy/move ctor is compiler-generated": true
+                }
+            },
+            {
+                "CallExpr": {
+                    "Location": 22
+                },
+                "Parameter": {
+                    "Func Identifier": "std::move",
+                    "Func Location": 1889,
+                    "Func Type": "class std::back_insert_iterator<class std::list<int, class std::allocator<int> > > (class std::__wrap_iter<int *>, class std::__wrap_iter<int *>, class std::back_insert_iterator<class std::list<int, class std::allocator<int> > >)",
+                    "Identifier": "__result",
+                    "Parm Type": "class std::back_insert_iterator<class std::list<int, class std::allocator<int> > >",
+                    "construction kind": "move",
+                    "copy/move ctor is compiler-generated": true
+                }
+            }
+        ]
     }
 }

--- a/test/unit/library/MoveVsMove2.cpp
+++ b/test/unit/library/MoveVsMove2.cpp
@@ -16,7 +16,7 @@ int main(int argc, char** argv){
     //
     std::vector<int> v;
     std::list<int> l;
-    std::move(v.begin(), v.end(), std::back_inserter(l));
+    std::move(v.begin(), v.end(), std::back_inserter(l)); // ATTENTION: this call to algorith:std::move will cause three move-constructed parameter to be detected
     //
     return std::move(0);
 

--- a/test/unit/library/MoveVsMove2.cpp.json
+++ b/test/unit/library/MoveVsMove2.cpp.json
@@ -33,6 +33,49 @@
                 ]
             }
         },
-        "copy or move construction": null
+        "copy or move construction": [
+            {
+                "CallExpr": {
+                    "Location": 19
+                },
+                "Parameter": {
+                    "Func Identifier": "std::move",
+                    "Func Location": 1889,
+                    "Func Type": "class std::back_insert_iterator<class std::list<int, class std::allocator<int> > > (class std::__wrap_iter<int *>, class std::__wrap_iter<int *>, class std::back_insert_iterator<class std::list<int, class std::allocator<int> > >)",
+                    "Identifier": "__first",
+                    "Parm Type": "class std::__wrap_iter<int *>",
+                    "construction kind": "move",
+                    "copy/move ctor is compiler-generated": true
+                }
+            },
+            {
+                "CallExpr": {
+                    "Location": 19
+                },
+                "Parameter": {
+                    "Func Identifier": "std::move",
+                    "Func Location": 1889,
+                    "Func Type": "class std::back_insert_iterator<class std::list<int, class std::allocator<int> > > (class std::__wrap_iter<int *>, class std::__wrap_iter<int *>, class std::back_insert_iterator<class std::list<int, class std::allocator<int> > >)",
+                    "Identifier": "__last",
+                    "Parm Type": "class std::__wrap_iter<int *>",
+                    "construction kind": "move",
+                    "copy/move ctor is compiler-generated": true
+                }
+            },
+            {
+                "CallExpr": {
+                    "Location": 19
+                },
+                "Parameter": {
+                    "Func Identifier": "std::move",
+                    "Func Location": 1889,
+                    "Func Type": "class std::back_insert_iterator<class std::list<int, class std::allocator<int> > > (class std::__wrap_iter<int *>, class std::__wrap_iter<int *>, class std::back_insert_iterator<class std::list<int, class std::allocator<int> > >)",
+                    "Identifier": "__result",
+                    "Parm Type": "class std::back_insert_iterator<class std::list<int, class std::allocator<int> > >",
+                    "construction kind": "move",
+                    "copy/move ctor is compiler-generated": true
+                }
+            }
+        ]
     }
 }

--- a/test/unit/movesemantics/AllArgs.cpp
+++ b/test/unit/movesemantics/AllArgs.cpp
@@ -1,0 +1,18 @@
+// RUN: rm %t1.ast.json || true
+// RUN: clang++ %s -emit-ast -o %t1.ast -std=c++17
+// RUN: %cxx-langstat --analyses=msa -emit-features -in %t1.ast -out %t1.ast.json -- -std=c++17
+// RUN: diff %t1.ast.json %s.json
+
+// Small test to ensure that with forEachArgumentWithParam matcher we analyze
+// all parm-arg pair and all relevant arguments' construction is output.
+
+class C{
+};
+
+void func(C c, C& c_r, C c2);
+
+int main(int argc, char** argv){
+    C c;
+    func(c, c, c);
+    C d = c;
+}

--- a/test/unit/movesemantics/AllArgs.cpp.json
+++ b/test/unit/movesemantics/AllArgs.cpp.json
@@ -1,0 +1,37 @@
+{
+    "msa": {
+        "std::move, std::forward usage": {
+            "func insts": null
+        },
+        "copy or move construction": [
+            {
+                "CallExpr": {
+                    "Location": 16
+                },
+                "Parameter": {
+                    "Func Identifier": "func",
+                    "Func Location": 12,
+                    "Func Type": "void (class C, class C &, class C)",
+                    "Identifier": "c",
+                    "Parm Type": "class C",
+                    "construction kind": "copy",
+                    "copy/move ctor is compiler-generated": true
+                }
+            },
+            {
+                "CallExpr": {
+                    "Location": 16
+                },
+                "Parameter": {
+                    "Func Identifier": "func",
+                    "Func Location": 12,
+                    "Func Type": "void (class C, class C &, class C)",
+                    "Identifier": "c2",
+                    "Parm Type": "class C",
+                    "construction kind": "copy",
+                    "copy/move ctor is compiler-generated": true
+                }
+            }
+        ]
+    }
+}

--- a/test/unit/movesemantics/Fields.cpp
+++ b/test/unit/movesemantics/Fields.cpp
@@ -1,0 +1,34 @@
+// RUN: rm %t1.ast.json || true
+// RUN: clang++ %s -emit-ast -o %t1.ast -std=c++14
+// RUN: %cxx-langstat --analyses=msa -emit-features -in %t1.ast -out %t1.ast.json -- -std=c++14
+// RUN: diff %t1.ast.json %s.json
+
+// Are passing field like c.d or temporary like c.f() reported correctly?
+//
+//
+
+class D {
+public:
+    ~D();
+};
+
+class C{
+public:
+    D d;
+    D f(){
+        return D();
+    }
+};
+
+void funcc(C c);
+
+void funcd(D d);
+
+int main(int argc, char** argv){
+    C c;
+    funcc(c);
+    funcd(c.d);
+    funcd(c.f()); // Copied since we're using C++14 here
+
+    // C c2 = C();
+}

--- a/test/unit/movesemantics/Fields.cpp.json
+++ b/test/unit/movesemantics/Fields.cpp.json
@@ -1,0 +1,51 @@
+{
+    "msa": {
+        "std::move, std::forward usage": {
+            "func insts": null
+        },
+        "copy or move construction": [
+            {
+                "CallExpr": {
+                    "Location": 29
+                },
+                "Parameter": {
+                    "Func Identifier": "funcc",
+                    "Func Location": 23,
+                    "Func Type": "void (class C)",
+                    "Identifier": "c",
+                    "Parm Type": "class C",
+                    "construction kind": "copy",
+                    "copy/move ctor is compiler-generated": true
+                }
+            },
+            {
+                "CallExpr": {
+                    "Location": 30
+                },
+                "Parameter": {
+                    "Func Identifier": "funcd",
+                    "Func Location": 25,
+                    "Func Type": "void (class D)",
+                    "Identifier": "d",
+                    "Parm Type": "class D",
+                    "construction kind": "copy",
+                    "copy/move ctor is compiler-generated": true
+                }
+            },
+            {
+                "CallExpr": {
+                    "Location": 31
+                },
+                "Parameter": {
+                    "Func Identifier": "funcd",
+                    "Func Location": 25,
+                    "Func Type": "void (class D)",
+                    "Identifier": "d",
+                    "Parm Type": "class D",
+                    "construction kind": "copy",
+                    "copy/move ctor is compiler-generated": true
+                }
+            }
+        ]
+    }
+}

--- a/test/unit/movesemantics/Pointers.cpp
+++ b/test/unit/movesemantics/Pointers.cpp
@@ -1,0 +1,24 @@
+// RUN: rm %t1.ast.json || true
+// RUN: clang++ %s -emit-ast -o %t1.ast -std=c++17
+// RUN: %cxx-langstat --analyses=msa -emit-features -in %t1.ast -out %t1.ast.json -- -std=c++17
+// RUN: diff %t1.ast.json %s.json
+
+// Test to see if pointers are reported or not.
+//
+//
+
+#include <utility>
+
+class C{};
+
+void func(C c);
+
+void func_p(C* c);
+
+int main(int argc, char** argv){
+    C c;
+    func(std::move(c));
+
+    func_p(&c);
+
+}

--- a/test/unit/movesemantics/Pointers.cpp.json
+++ b/test/unit/movesemantics/Pointers.cpp.json
@@ -1,0 +1,36 @@
+{
+    "msa": {
+        "std::move, std::forward usage": {
+            "func insts": {
+                "std::move": [
+                    {
+                        "location": 20,
+                        "arguments": {
+                            "non-type": [],
+                            "type": [
+                                "C &"
+                            ],
+                            "template": []
+                        }
+                    }
+                ]
+            }
+        },
+        "copy or move construction": [
+            {
+                "CallExpr": {
+                    "Location": 20
+                },
+                "Parameter": {
+                    "Func Identifier": "func",
+                    "Func Location": 14,
+                    "Func Type": "void (class C)",
+                    "Identifier": "c",
+                    "Parm Type": "class C",
+                    "construction kind": "move",
+                    "copy/move ctor is compiler-generated": true
+                }
+            }
+        ]
+    }
+}

--- a/test/unit/movesemantics/SmartPointers.cpp
+++ b/test/unit/movesemantics/SmartPointers.cpp
@@ -1,0 +1,25 @@
+// RUN: rm %t1.ast.json || true
+// RUN: clang++ %s -emit-ast -o %t1.ast -std=c++17
+// RUN: %cxx-langstat --analyses=msa -emit-features -in %t1.ast -out %t1.ast.json -- -std=c++17
+// RUN: diff %t1.ast.json %s.json
+
+// Same as with Vector.cpp, same problem with CXXBindTemporaryExpr.
+//
+//
+
+#include <memory>
+
+class C{};
+
+void func_p(std::unique_ptr<C> c_p);
+
+int main(int argc, char** argv){
+    std::unique_ptr<C> c_p = std::make_unique<C>();
+    // func_p(c_p); would illegally call copy constructor of unique_ptr
+    func_p(std::move(c_p));
+    func_p(std::move(std::make_unique<C>()));
+
+}
+
+// can try hasDescendant(cxxConstructExpr()), but don't want to match too much then
+// or hasDescendant(cxxConstructExpr) or is(cxxConstructExpr)

--- a/test/unit/movesemantics/SmartPointers.cpp.json
+++ b/test/unit/movesemantics/SmartPointers.cpp.json
@@ -1,0 +1,60 @@
+{
+    "msa": {
+        "std::move, std::forward usage": {
+            "func insts": {
+                "std::move": [
+                    {
+                        "location": 19,
+                        "arguments": {
+                            "non-type": [],
+                            "type": [
+                                "std::unique_ptr<C, std::default_delete<C> > &"
+                            ],
+                            "template": []
+                        }
+                    },
+                    {
+                        "location": 20,
+                        "arguments": {
+                            "non-type": [],
+                            "type": [
+                                "std::unique_ptr<C, std::default_delete<C> >"
+                            ],
+                            "template": []
+                        }
+                    }
+                ]
+            }
+        },
+        "copy or move construction": [
+            {
+                "CallExpr": {
+                    "Location": 19
+                },
+                "Parameter": {
+                    "Func Identifier": "func_p",
+                    "Func Location": 14,
+                    "Func Type": "void (class std::unique_ptr<class C, struct std::default_delete<class C> >)",
+                    "Identifier": "c_p",
+                    "Parm Type": "class std::unique_ptr<class C, struct std::default_delete<class C> >",
+                    "construction kind": "move",
+                    "copy/move ctor is compiler-generated": false
+                }
+            },
+            {
+                "CallExpr": {
+                    "Location": 20
+                },
+                "Parameter": {
+                    "Func Identifier": "func_p",
+                    "Func Location": 14,
+                    "Func Type": "void (class std::unique_ptr<class C, struct std::default_delete<class C> >)",
+                    "Identifier": "c_p",
+                    "Parm Type": "class std::unique_ptr<class C, struct std::default_delete<class C> >",
+                    "construction kind": "move",
+                    "copy/move ctor is compiler-generated": false
+                }
+            }
+        ]
+    }
+}

--- a/test/unit/movesemantics/Vector.cpp
+++ b/test/unit/movesemantics/Vector.cpp
@@ -1,0 +1,20 @@
+// RUN: rm %t1.ast.json || true
+// RUN: clang++ %s -emit-ast -o %t1.ast -std=c++17
+// RUN: %cxx-langstat --analyses=msa -emit-features -in %t1.ast -out %t1.ast.json -- -std=c++17
+// RUN: diff %t1.ast.json %s.json
+
+// Test copying/moving of vector. Needs that weird CXXBindTemporaryExpr in the
+// clang AST, don't know why.
+//
+
+#include <vector>
+
+void func(std::vector<int> v){
+
+}
+
+int main(int argc, char** argv){
+    std::vector<int> v = {1};
+    func(std::move(v));
+    v.emplace_back(2);
+}

--- a/test/unit/movesemantics/Vector.cpp.json
+++ b/test/unit/movesemantics/Vector.cpp.json
@@ -1,0 +1,36 @@
+{
+    "msa": {
+        "std::move, std::forward usage": {
+            "func insts": {
+                "std::move": [
+                    {
+                        "location": 18,
+                        "arguments": {
+                            "non-type": [],
+                            "type": [
+                                "std::vector<int, std::allocator<int> > &"
+                            ],
+                            "template": []
+                        }
+                    }
+                ]
+            }
+        },
+        "copy or move construction": [
+            {
+                "CallExpr": {
+                    "Location": 18
+                },
+                "Parameter": {
+                    "Func Identifier": "func",
+                    "Func Location": 12,
+                    "Func Type": "void (class std::vector<int, class std::allocator<int> >)",
+                    "Identifier": "v",
+                    "Parm Type": "class std::vector<int, class std::allocator<int> >",
+                    "construction kind": "move",
+                    "copy/move ctor is compiler-generated": false
+                }
+            }
+        ]
+    }
+}

--- a/test/unit/movesemantics/cxx14.cpp
+++ b/test/unit/movesemantics/cxx14.cpp
@@ -1,0 +1,18 @@
+// RUN: rm %t1.ast.json || true
+// RUN: clang++ %s -emit-ast -o %t1.ast -std=c++14
+// RUN: %cxx-langstat --analyses=msa -emit-features -in %t1.ast -out %t1.ast.json -- -std=c++14
+// RUN: diff %t1.ast.json %s.json
+
+// construction is elidable prior to C++17. -> report construction kind "move" in
+// cxx14.cpp.json. Elision in C++14 not yet mandated by standard.
+// MSA improvement: report if elidable or not.
+
+class C {
+
+};
+
+void f(C c);
+
+int main(int argc, char** argv){
+    f(C());
+}

--- a/test/unit/movesemantics/cxx14.cpp.json
+++ b/test/unit/movesemantics/cxx14.cpp.json
@@ -1,0 +1,23 @@
+{
+    "msa": {
+        "std::move, std::forward usage": {
+            "func insts": null
+        },
+        "copy or move construction": [
+            {
+                "CallExpr": {
+                    "Location": 17
+                },
+                "Parameter": {
+                    "Func Identifier": "f",
+                    "Func Location": 14,
+                    "Func Type": "void (class C)",
+                    "Identifier": "c",
+                    "Parm Type": "class C",
+                    "construction kind": "move",
+                    "copy/move ctor is compiler-generated": true
+                }
+            }
+        ]
+    }
+}

--- a/test/unit/movesemantics/cxx17.cpp
+++ b/test/unit/movesemantics/cxx17.cpp
@@ -1,0 +1,18 @@
+// RUN: rm %t1.ast.json || true
+// RUN: clang++ %s -emit-ast -o %t1.ast -std=c++17
+// RUN: %cxx-langstat --analyses=msa -emit-features -in %t1.ast -out %t1.ast.json -- -std=c++17
+// RUN: diff %t1.ast.json %s.json
+
+// construction is elided in C++17. -> report construction kind "unknown" in
+// cxx17.cpp.json
+// MSA improvement: report something better than "unknown".
+
+class C {
+
+};
+
+void f(C c);
+
+int main(int argc, char** argv){
+    f(C());
+}

--- a/test/unit/movesemantics/cxx17.cpp.json
+++ b/test/unit/movesemantics/cxx17.cpp.json
@@ -1,0 +1,23 @@
+{
+    "msa": {
+        "std::move, std::forward usage": {
+            "func insts": null
+        },
+        "copy or move construction": [
+            {
+                "CallExpr": {
+                    "Location": 17
+                },
+                "Parameter": {
+                    "Func Identifier": "f",
+                    "Func Location": 14,
+                    "Func Type": "void (class C)",
+                    "Identifier": "c",
+                    "Parm Type": "class C",
+                    "construction kind": "unknown",
+                    "copy/move ctor is compiler-generated": true
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
… types with nontrivial destructor by changing matcher to allow CXXBindTemporaryExpr around CXXConstructExpr, don't understand yet why that happens, added new test cases